### PR TITLE
Add marketplace initial setup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "claude-skills",
+  "description": "A personal collection of Claude Code plugins and skills by tetsumaru",
+  "owner": {
+    "name": "tetsumaru",
+  },
+  "plugins": []
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.DS_Store
+*.log

--- a/README.md
+++ b/README.md
@@ -1,34 +1,38 @@
 # claude-skills
 
-Personal Claude Code skills collection, optimized for mobile remote control development via [cmux](https://cmux.dev).
+Personal Claude Code plugins and skills marketplace by tetsumaru.
+
+## Structure
+
+- **`/plugins`** - Plugins developed and maintained in this repository
+- **`/external_plugins`** - Third-party or community plugins
+
+## Installation
+
+```bash
+/plugin install <plugin-name>@claude-skills
+```
+
+or browse via `/plugin > Discover`
 
 ## Design Principles
 
-- **SKILL.md is under 50 lines** — flow and pointers only
-- **No inline code blocks** — all logic lives in `scripts/`
-- **Docs go in `references/`** — one file per topic
-- **Script output goes to log files** — stdout prints only the path to save tokens
+- **SKILL.md is under 50 lines** -- flow and pointers only
+- **No inline code blocks** -- all logic lives in `scripts/`
+- **Docs go in `references/`** -- one file per topic
+- **Script output goes to log files** -- stdout prints only the path to save tokens
 
-## Skills
+## Plugin Structure
 
-| Skill | Description |
-|-------|-------------|
-| [rc-workspaces](skills/rc-workspaces/) | Bulk-start remote control sessions across all cmux workspaces |
-| [create-skill](skills/create-skill/) | Create or refactor skills following the design principles above |
-| [issue-implement](skills/issue-implement/) | Pick up a GitHub issue and deliver a PR end-to-end (1 issue = 1 PR) |
-
-## Setup
-
-Copy a skill into your Claude Code skills directory:
-
-```bash
-cp -r skills/<skill-name> ~/.claude/skills/
 ```
-
-Or symlink for easy updates:
-
-```bash
-ln -s "$(pwd)/skills/<skill-name>" ~/.claude/skills/<skill-name>
+plugin-name/
+├── .claude-plugin/
+│   └── plugin.json      # Plugin metadata (required)
+├── .mcp.json            # MCP server configuration (optional)
+├── commands/            # Slash commands (optional)
+├── agents/              # Agent definitions (optional)
+├── skills/              # Skill definitions (optional)
+└── README.md            # Documentation
 ```
 
 ## License


### PR DESCRIPTION
## Summary
- `.claude-plugin/marketplace.json` を追加（プラグインマーケットプレイスのメタデータ）
- `plugins/`, `external_plugins/` ディレクトリを構成
- README をマーケットプレイス構造に合わせて更新
- `.gitignore` を追加

## Test plan
- [ ] `marketplace.json` が有効なJSONであること
- [ ] `/plugin install` でこのリポジトリを参照できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)